### PR TITLE
Unidoc above v2.0.1 is no longer free, choose v2.0.1 in go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/ajaxray/markpdf
+
+go 1.12
+
+require (
+	github.com/boombuler/barcode v1.0.0 // indirect
+	github.com/ogier/pflag v0.0.1
+	github.com/unidoc/unidoc v2.0.1+incompatible
+	golang.org/x/image v0.0.0-20201208152932-35266b937fa6 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/boombuler/barcode v1.0.0 h1:s1TvRnXwL2xJRaccrdcBQMZxq6X7DvsMogtmJeHDdrc=
+github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
+github.com/ogier/pflag v0.0.1 h1:RW6JSWSu/RkSatfcLtogGfFgpim5p7ARQ10ECk5O750=
+github.com/ogier/pflag v0.0.1/go.mod h1:zkFki7tvTa0tafRvTBIZTvzYyAu6kQhPZFnshFFPE+g=
+github.com/unidoc/unidoc v2.0.1+incompatible h1:IwNeWnUTacFQzYCRzHQj+33zOsbjtHMa+Ukw/1T+Xh8=
+github.com/unidoc/unidoc v2.0.1+incompatible/go.mod h1:xz5DRu10sgNndY6/LrqtXytidQ/aXastVtkIVSxIj3Q=
+golang.org/x/image v0.0.0-20201208152932-35266b937fa6 h1:nfeHNc1nAqecKCy2FCy4HY+soOOe5sDLJ/gZLbx6GYI=
+golang.org/x/image v0.0.0-20201208152932-35266b937fa6/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Unidoc above v2.0.1 is no longer free, choose v2.0.1 in go.mod file to get rid of Unidoc's lisence watermarks