### PR TITLE
added flag to scale image to desired percentage

### DIFF
--- a/img_watermark.go
+++ b/img_watermark.go
@@ -18,6 +18,11 @@ func adjustImagePosition(watermarkImg *creator.Image, c *creator.Creator) {
 	debugInfo(fmt.Sprintf("Watermark Width  : %v", watermarkImg.Width()))
 	debugInfo(fmt.Sprintf("Watermark Height : %v", watermarkImg.Height()))
 
+
+	if scaleImage != 100 {
+		debugInfo(fmt.Sprintf("Scaling to %v", scaleImage))
+		watermarkImg.ScaleToHeight(scaleImage * watermarkImg.Width() / 100)
+	}
 	if scaleWCenter {
 		watermarkImg.ScaleToWidth(c.Context().PageWidth)
 		offsetX = 0

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	pdf "github.com/unidoc/unidoc/pdf/model"
 )
 
-var offsetX, offsetY, fontSize float64
+var offsetX, offsetY, scaleImage, fontSize float64
 var scaleH, scaleW, scaleHCenter, scaleWCenter, center, verbose, version bool
 var opacity, angle float64
 var font, color string
@@ -22,6 +22,7 @@ const (
 func init() {
 	flag.Float64VarP(&offsetX, "offset-x", "x", 0, "Offset from left (or right for negative number).")
 	flag.Float64VarP(&offsetY, "offset-y", "y", 0, "Offset from top (or bottom for negative number).")
+	flag.Float64VarP(&scaleImage, "scale", "p", 100, "Scale Image to desired percentage.")
 	flag.BoolVarP(&center, "center", "c", false, "Set position at page center. Offset X and Y will be ignored.")
 	flag.BoolVarP(&scaleW, "scale-width", "w", false, "Scale Image to page width. If set, offset X will be ignored.")
 	flag.BoolVarP(&scaleH, "scale-height", "h", false, "Scale Image to page height. If set, top offset Y will be ignored.")


### PR DESCRIPTION
@ajaxray Added support to add `scale` / `p` flag to scale watermark image to desired percentage. 
Currently this package only has support to either scale image to full page-height or page-width, but not to scale relative to image itself. This is especially handy while handling bigger images in watermark (like original logos) which are bigger in size and we may want to scale it to lower dimensions. 

Usage: add flag :
`-p 30` or `--scale 50` to scale to 50% of original size of watermark image.
