### PR TITLE
[Feature] Image tiles all over the page

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Currently the following font names are supported:
 - **Specifying Colors**: write them as 6 or 3 digit hexadecilal as used in CSS, without the #
 
 - `--color`, `--font` and `--font-size` flag has no impact for Image watermarking
-- `--scale-*` and `--opacity` flag has no impact for Text watermarking
+- `--scale-*`, `--tiles` and `--opacity` flag has no impact for Text watermarking
 - Negative offset will set content positioning from opposite side (right for offsetX and botom from offsetY)
 - Text with opacity is not supported at this moment. Instead, you can [create a transperent background PNG image](http://www.picturetopeople.org/text_generator/others/transparent/transparent-text-generator.html) with your text and then use it for watermarking.
 
@@ -101,7 +101,7 @@ Currently the following font names are supported:
 ✅ Configure image rotation angle  
 ✅ Options to Stretch watermark to page width or height, proportionately  
 ✅ Options to Stretch watermark to page width or height at the middle of page  
-◻️ Tile Image all over the page  
+✅ Tile Image all over the page  
 ✅ Render text on every page  
 ✅ Configure text color, style and font  
 ◻️ Configure text opacity  

--- a/README.md
+++ b/README.md
@@ -56,7 +56,17 @@ markpdf "path/to/source.pdf" "img/logo.png" "path/to/output.pdf" -Wo 0.3
 # stretch full with of page at page bottom
 markpdf "path/to/source.pdf" "img/logo.png" "path/to/output.pdf" --scale-width --offset-y=-10
 markpdf "path/to/source.pdf" "img/logo.png" "path/to/output.pdf" -wy -10
-```
+
+# Scale the image to desired percentage
+markpdf "path/to/source.pdf" "img/logo.png" "path/to/output.pdf" --scale=30
+
+# Add image as tiles all over the page
+markpdf "path/to/source.pdf" "img/logo.png" "path/to/output.pdf" --tiles
+
+# Add image as tiles with interleaved spacing
+markpdf "path/to/source.pdf" "img/logo.png" "path/to/output.pdf" --tiles --spacing=20
+``
+
 
 ### Text watermarking
 

--- a/img_watermark.go
+++ b/img_watermark.go
@@ -8,10 +8,34 @@ import (
 )
 
 func drawImage(watermarkImg *creator.Image, c *creator.Creator) {
-	watermarkImg.SetPos(offsetX, offsetY)
 	watermarkImg.SetOpacity(opacity)
 	watermarkImg.SetAngle(angle)
+	if tiles {
+		repeatTiles(watermarkImg, c)
+		return
+	}
+	watermarkImg.SetPos(offsetX, offsetY)
 	_ = c.Draw(watermarkImg)
+}
+
+func repeatTiles(watermarkImg *creator.Image, c *creator.Creator) {
+	w := watermarkImg.Width()
+	h := watermarkImg.Height()
+	pw := c.Context().PageWidth
+	ph := c.Context().PageHeight
+
+	nw := math.Ceil(pw / w)
+	nh := math.Ceil(ph / h)
+
+	debugInfo(fmt.Sprintf("Settings tiles of %v x %v", nw, nh))
+	for i := 0; i < int(nw); i++ {
+		x := w * float64(i)
+		for j := 0; j < int(nh); j++ {
+			y := h * float64(j)
+			watermarkImg.SetPos(x, y)
+			_ = c.Draw(watermarkImg)
+		}
+	}
 }
 
 func adjustImagePosition(watermarkImg *creator.Image, c *creator.Creator) {
@@ -22,6 +46,10 @@ func adjustImagePosition(watermarkImg *creator.Image, c *creator.Creator) {
 	if scaleImage != 100 {
 		debugInfo(fmt.Sprintf("Scaling to %v", scaleImage))
 		watermarkImg.ScaleToHeight(scaleImage * watermarkImg.Width() / 100)
+	}
+	if tiles {
+		offsetX, offsetY = 0, 0
+		return
 	}
 	if scaleWCenter {
 		watermarkImg.ScaleToWidth(c.Context().PageWidth)

--- a/img_watermark.go
+++ b/img_watermark.go
@@ -18,6 +18,11 @@ func adjustImagePosition(watermarkImg *creator.Image, c *creator.Creator) {
 	debugInfo(fmt.Sprintf("Watermark Width  : %v", watermarkImg.Width()))
 	debugInfo(fmt.Sprintf("Watermark Height : %v", watermarkImg.Height()))
 
+
+	if scaleImage != 100 {
+		debugInfo(fmt.Sprintf("Scaling to %v", scaleImage))
+		watermarkImg.ScaleToHeight(scaleImage * watermarkImg.Width() / 100)
+	}
 	if scaleWCenter {
 		watermarkImg.ScaleToWidth(c.Context().PageWidth)
 		offsetX = 0

--- a/img_watermark.go
+++ b/img_watermark.go
@@ -18,33 +18,13 @@ func drawImage(watermarkImg *creator.Image, c *creator.Creator) {
 	_ = c.Draw(watermarkImg)
 }
 
-func repeatTiles(watermarkImg *creator.Image, c *creator.Creator) {
-	w := watermarkImg.Width()
-	h := watermarkImg.Height()
-	pw := c.Context().PageWidth
-	ph := c.Context().PageHeight
-
-	nw := math.Ceil(pw / w)
-	nh := math.Ceil(ph / h)
-
-	debugInfo(fmt.Sprintf("Settings tiles of %v x %v", nw, nh))
-	for i := 0; i < int(nw); i++ {
-		x := w * float64(i)
-		for j := 0; j < int(nh); j++ {
-			y := h * float64(j)
-			watermarkImg.SetPos(x, y)
-			_ = c.Draw(watermarkImg)
-		}
-	}
-}
-
 func adjustImagePosition(watermarkImg *creator.Image, c *creator.Creator) {
 	debugInfo(fmt.Sprintf("Watermark Width  : %v", watermarkImg.Width()))
 	debugInfo(fmt.Sprintf("Watermark Height : %v", watermarkImg.Height()))
 
 
 	if scaleImage != 100 {
-		debugInfo(fmt.Sprintf("Scaling to %v", scaleImage))
+		debugInfo(fmt.Sprintf("Scaling to %v%%", scaleImage))
 		watermarkImg.ScaleToHeight(scaleImage * watermarkImg.Width() / 100)
 	}
 	if tiles {

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	pdf "github.com/unidoc/unidoc/pdf/model"
 )
 
-var offsetX, offsetY, scaleImage, fontSize float64
+var offsetX, offsetY, scaleImage, fontSize, spacing float64
 var scaleH, scaleW, scaleHCenter, scaleWCenter, center, tiles, verbose, version bool
 var opacity, angle float64
 var font, color string
@@ -35,7 +35,9 @@ func init() {
 
 	flag.Float64VarP(&opacity, "opacity", "o", 0.5, "Opacity of watermark. float between 0 to 1.")
 	flag.Float64VarP(&angle, "angle", "a", 0, "Angle of rotation. between 0 to 360, counter clock-wise.")
+
 	flag.BoolVarP(&tiles, "tiles", "t", false, "Repeat watermark as tiles on page. All offsets will be ignored.")
+	flag.Float64VarP(&spacing, "spacing", "z", 0, "Repeat watermark as tiles on page. All offsets will be ignored.")
 
 	flag.BoolVarP(&verbose, "verbose", "v", false, "Display debug information.")
 	flag.BoolVarP(&version, "version", "V", false, "Display Version information.")

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 var offsetX, offsetY, scaleImage, fontSize float64
-var scaleH, scaleW, scaleHCenter, scaleWCenter, center, verbose, version bool
+var scaleH, scaleW, scaleHCenter, scaleWCenter, center, tiles, verbose, version bool
 var opacity, angle float64
 var font, color string
 
@@ -35,6 +35,7 @@ func init() {
 
 	flag.Float64VarP(&opacity, "opacity", "o", 0.5, "Opacity of watermark. float between 0 to 1.")
 	flag.Float64VarP(&angle, "angle", "a", 0, "Angle of rotation. between 0 to 360, counter clock-wise.")
+	flag.BoolVarP(&tiles, "tiles", "t", false, "Repeat watermark as tiles on page. All offsets will be ignored.")
 
 	flag.BoolVarP(&verbose, "verbose", "v", false, "Display debug information.")
 	flag.BoolVarP(&version, "version", "V", false, "Display Version information.")

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	pdf "github.com/unidoc/unidoc/pdf/model"
 )
 
-var offsetX, offsetY, fontSize float64
+var offsetX, offsetY, scaleImage, fontSize float64
 var scaleH, scaleW, scaleHCenter, scaleWCenter, center, verbose, version bool
 var opacity, angle float64
 var font, color string
@@ -22,6 +22,7 @@ const (
 func init() {
 	flag.Float64VarP(&offsetX, "offset-x", "x", 0, "Offset from left (or right for negative number).")
 	flag.Float64VarP(&offsetY, "offset-y", "y", 0, "Offset from top (or bottom for negative number).")
+	flag.Float64VarP(&scaleImage, "scale", "p", 100, "Scale Image to desired percentage.")
 	flag.BoolVarP(&center, "center", "c", false, "Set position at page center. Offset X and Y will be ignored.")
 	flag.BoolVarP(&scaleW, "scale-width", "w", false, "Scale Image to page width. If set, offset X will be ignored.")
 	flag.BoolVarP(&scaleH, "scale-height", "h", false, "Scale Image to page height. If set, top offset Y will be ignored.")

--- a/text_watermark.go
+++ b/text_watermark.go
@@ -22,6 +22,12 @@ func drawText(p *creator.Paragraph, c *creator.Creator) {
 	p.SetColor(creator.ColorRGBFromHex("#" + color))
 	p.SetAngle(angle)
 
+	// Encountering problem with tiles and text watermark. Contributions welcome.
+	//if tiles {
+	//	repeatTiles(p, c)
+	//	return
+	//}
+
 	_ = c.Draw(p)
 }
 
@@ -29,7 +35,11 @@ func adjustTextPosition(p *creator.Paragraph, c *creator.Creator) {
 	p.SetTextAlignment(creator.TextAlignmentLeft)
 	p.SetEnableWrap(false)
 
-	if center {
+	if tiles {
+		p.SetWidth(p.Width()) // Not working without setting it manually
+		p.SetTextAlignment(creator.TextAlignmentCenter)
+		offsetX, offsetY = 0, 0
+	} else if center {
 		p.SetWidth(p.Width()) // Not working without setting it manually
 		p.SetTextAlignment(creator.TextAlignmentCenter)
 

--- a/tiles.go
+++ b/tiles.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"github.com/unidoc/unidoc/pdf/creator"
+	"math"
+)
+
+// Watermarkable is a common interface for watermarkable image or paragraph
+type Watermarkable interface {
+	creator.VectorDrawable
+	SetPos(x, y float64)
+}
+
+func repeatTiles(watermark Watermarkable, c *creator.Creator) {
+	w := watermark.Width()
+	h := watermark.Height()
+	pw := c.Context().PageWidth
+	ph := c.Context().PageHeight
+
+	nw := math.Ceil(pw / w)
+	nh := math.Ceil(ph / h)
+
+	debugInfo(fmt.Sprintf("Settings tiles of %v x %v", nw, nh))
+	for i := 0; i < int(nw); i++ {
+		x := w * float64(i)
+		for j := 0; j < int(nh); j++ {
+			y := h * float64(j)
+			watermark.SetPos(x + spacing * float64(i), y + spacing * float64(j))
+			err := c.Draw(watermark)
+			if err != nil {
+				fatalIfError(err, fmt.Sprintf("Error %s", err))
+			}
+		}
+	}
+}


### PR DESCRIPTION
Synatax:
```
markpdf pdf.pdf ~/Downloads/logo.jpeg out.pdf -p10 -t
```
In above syntax, using `-p` to scale the image to 10% and `-t` to generate tiles all over the page. Result: pattern like below:
<img width="1062" alt="image" src="https://user-images.githubusercontent.com/530850/194920315-b119b7e4-4925-491b-9a1e-db200e9a504e.png">

You can also use an additional flag `-z` or `--spacing` to add spacing b/w the tiles.
```
markpdf pdf.pdf ~/Downloads/logo.jpeg out.pdf -p10 -t -z20
```
<img width="760" alt="image" src="https://user-images.githubusercontent.com/530850/194920496-21223dcb-bbfb-4949-96aa-8f95b4435029.png">
