### PR TITLE
Horizontal aligned text feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ markpdf "path/to/source.pdf" "The Company Name" "path/to/output.pdf" -x -20 -y 2
 markpdf "path/to/source.pdf" "The Company Name" "path/to/output.pdf" --center --font=times_bold_italic --color=0000FF
 markpdf "path/to/source.pdf" "The Company Name" "path/to/output.pdf" -cf times_bold_italic -l 0000FF
 
+# Place text horizontally center with 50px offset vertically from edge
+markpdf "path/to/source.pdf" "The Company Name" "path/to/output.pdf" --horizontal-b-center -y 50
+
+# Place text horizontally center with 50px offset vertically
+# with bold-italic "Times Roman" font
+markpdf "path/to/source.pdf" "The Company Name" "path/to/output.pdf" -by 50
+
 # Place text at center with large bold-italic "Times Roman" font in blue color
 markpdf "path/to/source.pdf" "The Company Name" "path/to/output.pdf" --center --font=times_bold_italic --font-size=24.0 --color=0000FF
 markpdf "path/to/source.pdf" "The Company Name" "path/to/output.pdf" -cf times_bold_italic -s 24.0 -l 0000FF

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 var offsetX, offsetY, scaleImage, fontSize, spacing float64
-var scaleH, scaleW, scaleHCenter, scaleWCenter, center, tiles, verbose, version bool
+var scaleH, scaleW, scaleHCenter, scaleWCenter, center, horizontalCenter, tiles, verbose, version bool
 var opacity, angle float64
 var font, color string
 
@@ -26,6 +26,7 @@ func init() {
 	flag.Float64VarP(&offsetY, "offset-y", "y", 0, "Offset from top (or bottom for negative number).")
 	flag.Float64VarP(&scaleImage, "scale", "p", 100, "Scale Image to desired percentage.")
 	flag.BoolVarP(&center, "center", "c", false, "Set position at page center. Offset X and Y will be ignored.")
+	flag.BoolVarP(&horizontalCenter, "horizontal-b-center", "b", false, "Set horizontal position at page center. Offset X will be ignored.")
 	flag.BoolVarP(&scaleW, "scale-width", "w", false, "Scale Image to page width. If set, offset X will be ignored.")
 	flag.BoolVarP(&scaleH, "scale-height", "h", false, "Scale Image to page height. If set, top offset Y will be ignored.")
 	flag.BoolVarP(&scaleWCenter, "scale-width-center", "W", false, "Scale Image to page width and Y will be set at middle.")

--- a/text_watermark.go
+++ b/text_watermark.go
@@ -47,6 +47,14 @@ func adjustTextPosition(p *creator.Paragraph, c *creator.Creator) {
 
 		offsetX = (c.Context().PageWidth / 2) - (p.Width() / 2)
 		offsetY = (c.Context().PageHeight / 2) - (p.Height() / 2)
+	} else if horizontalCenter {
+		p.SetWidth(p.Width()) // Not working without setting it manually
+		p.SetTextAlignment(creator.TextAlignmentCenter)
+		offsetX = (c.Context().PageWidth / 2) - (p.Width() / 2)
+		if offsetY < 0 {
+			offsetY = c.Context().PageHeight - (math.Abs(offsetY) + p.Height())
+		}
+
 	} else {
 		if offsetX < 0 {
 			p.SetWidth(p.Width()) // Not working without setting it manually


### PR DESCRIPTION
Hi Anis,

I have recently added a feature for the _text watermarking_, where the text can now be horizontally centered, but still specify the vertical offset of where you would like the text to be (top or bottom)

here are 2 examples of the new addition:
`go run . blank.pdf "WATERMARK FOR EMILIO ROCHE" blankNew.pdf --horizontal-b-center -y -50 -f times_bold_italic -l 0000FF`
![image](https://github.com/ajaxray/markpdf/assets/32501779/23c72dd7-ec33-42e6-8d54-510f756e243d)

`go run . blank.pdf "WATERMARK FOR EMILIO ROCHE" blankNew.pdf -by 100`
![image](https://github.com/ajaxray/markpdf/assets/32501779/84bf72c0-1ccf-4fc5-892c-47fdae0cafb1)

I hope you accept this PR! 😄 

- Emilio